### PR TITLE
Support valueUpdate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ For select and checklist, you can pass options just as you would to knockout:
 <span data-bind="editable: gender, editableOptions: {pk: id, options: genders, optionsText: 'text', optionsValue: 'id'}"></span>
 ```
 
+For select only, you can also pass in the `valueUpdate` option (see http://knockoutjs.com/documentation/value-binding.html):
+```html
+<span data-bind="editable: comment, editableOptions: { /* ... */, valueUpdate: 'keyup'}"></span>
+```
+
 optionsCaption is used to set editable.prepend
 
 ###knockout.validation

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For select and checklist, you can pass options just as you would to knockout:
 <span data-bind="editable: gender, editableOptions: {pk: id, options: genders, optionsText: 'text', optionsValue: 'id'}"></span>
 ```
 
-For select only, you can also pass in the `valueUpdate` option (see http://knockoutjs.com/documentation/value-binding.html):
+For textarea only, you can also pass in the `valueUpdate` option (see http://knockoutjs.com/documentation/value-binding.html):
 ```html
 <span data-bind="editable: comment, editableOptions: { /* ... */, valueUpdate: 'keyup'}"></span>
 ```

--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ You can pass through any editable options with:
 Note the pk can be an observable since x-editable just calls it as a function.
 The option editableOptions.visible can be passed an observable, this sets the x-editable toggle to 'manual', then uses the observable to fire the 'show' method
 
+You can also pass in the `bindTextInput` option for two-way updates (see http://knockoutjs.com/documentation/textinput-binding.html):
+```html
+<span data-bind="editable: comment, editableOptions: {/* ... */, bindTextInput: true}"></span>
+```
+
 ###select, checklist and typeahead options
 For select and checklist, you can pass options just as you would to knockout:
 ```html
 <span data-bind="editable: gender, editableOptions: {pk: id, options: genders, optionsText: 'text', optionsValue: 'id'}"></span>
-```
-
-For textarea only, you can also pass in the `valueUpdate` option (see http://knockoutjs.com/documentation/value-binding.html):
-```html
-<span data-bind="editable: comment, editableOptions: { /* ... */, valueUpdate: 'keyup'}"></span>
 ```
 
 optionsCaption is used to set editable.prepend

--- a/knockout.x-editable.js
+++ b/knockout.x-editable.js
@@ -73,12 +73,27 @@
 			//create editable
 			var $editable = $element.editable(editableOptions);
 
-			//update observable on save
-			if (ko.isObservable(value)) {
-				$editable.on('save.ko', function (e, params) {
-					value(params.newValue);
-				})
-			};
+			//update observable as instructed by valueUpdate option, if requested;
+			//or save otherwise
+            if (editableOptions.valueUpdate && editableOptions.type === 'textarea') {
+                $editable.on('shown.ko', function(event, editable)
+                {
+                    // distinguishes x-editable 'shown' event from bootstrap one
+                    if (arguments.length != 2) return;
+
+                    ko.applyBindingsToNode(editable.input.$input[0],
+                        {
+                            value: value,
+                            valueUpdate: editableOptions.valueUpdate
+                        }, value);
+                });
+            } else {
+                if (ko.isObservable(value)) {
+                    $editable.on('save.ko', function (e, params) {
+                        value(params.newValue);
+                    })
+                }
+            }
 
 			if (editableOptions.save) {
 				$editable.on('save', editableOptions.save);

--- a/knockout.x-editable.js
+++ b/knockout.x-editable.js
@@ -73,27 +73,26 @@
 			//create editable
 			var $editable = $element.editable(editableOptions);
 
-			//update observable as instructed by valueUpdate option, if requested;
+			//apply textInput binding, if requested;
 			//or save otherwise
-            if (editableOptions.valueUpdate && editableOptions.type === 'textarea') {
-                $editable.on('shown.ko', function(event, editable)
-                {
-                    // distinguishes x-editable 'shown' event from bootstrap one
-                    if (arguments.length != 2) return;
+			if (editableOptions.bindTextInput && editableOptions.bindTextInput === true) {
+				$editable.on('shown.ko', function(event, editable)
+				{
+					// distinguishes x-editable 'shown' event from bootstrap one
+					if (arguments.length != 2) return;
 
-                    ko.applyBindingsToNode(editable.input.$input[0],
-                        {
-                            value: value,
-                            valueUpdate: editableOptions.valueUpdate
-                        }, value);
-                });
-            } else {
-                if (ko.isObservable(value)) {
-                    $editable.on('save.ko', function (e, params) {
-                        value(params.newValue);
-                    })
-                }
-            }
+					ko.applyBindingsToNode(editable.input.$input[0],
+						{
+							textInput: value
+						}, value);
+				});
+			} else {
+				if (ko.isObservable(value)) {
+					$editable.on('save.ko', function (e, params) {
+						value(params.newValue);
+					})
+				}
+			}
 
 			if (editableOptions.save) {
 				$editable.on('save', editableOptions.save);


### PR DESCRIPTION
Enables the page developer to choose whether to have x-editable update
the observable on blur or whether to update it live, via the
valueUpdate option.