### PR TITLE
Adds submitFullDate option

### DIFF
--- a/knockout.x-editable.js
+++ b/knockout.x-editable.js
@@ -24,6 +24,13 @@
 					}
 				});
 			}
+
+                       if (editableOptions.submitFullDate) {
+                                editableOptions.params = function(params) {
+                                        params.value = new Date(params.value).toISOString()
+                                        return params
+                                }
+                       }
 			
 			//wrap calls to knockout.validation
 			if (!editableOptions.validate && value.isValid) {


### PR DESCRIPTION
This adds a convenience option called 'submitFullDate' to the editableOptions object. I've had a pretty hard time adjusting for time zones when x-editable submits dates. This option makes sure to submit an ISO String version of the date when set to true by sending the x-editable library a params function. 

Not sure if you consider this a valuable or valid feature for what this binding does. This binding has been super helpful but one of my pet peeves is creating otherwise unnecessary observables to pass through to x-editable, and I thought this would be succint and convenient.
